### PR TITLE
Add flake8 and editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab
+
+[*.diff]
+trim_trailing_whitespace = false
+
+[*.{html,yml}]
+indent_size = 2

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
 exclude = *migrations*
+ignore = E501
 statistics = true

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+exclude = *migrations*
+statistics = true

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,4 @@ test:
 	STRIPE_API_KEY_SECRET=dummy \
 	coverage run manage.py test
 	coverage report
+	flake8 .

--- a/manage.py
+++ b/manage.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
         # issue is really that Django is missing to avoid masking other
         # exceptions on Python 2.
         try:
-            import django
+            import django  # noqa: this isn't intended to be used.
         except ImportError:
             raise ImportError(
                 "Couldn't import Django. Are you sure it's installed and "

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 coverage
 Django
+flake8
 stripe
 django-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,10 @@
 coverage==4.4.1
 django-dotenv==1.4.1
 django==1.11.1
+flake8==3.3.0
+mccabe==0.6.1             # via flake8
+pycodestyle==2.3.1        # via flake8
+pyflakes==1.5.0           # via flake8
 pytz==2017.2              # via django
 requests==2.14.2          # via stripe
 stripe==1.55.2

--- a/tickets/actions.py
+++ b/tickets/actions.py
@@ -1,5 +1,5 @@
 from .invitation_mailer import send_invitation_mail
-from .models import Order, Ticket
+from .models import Order
 from .stripe_integration import create_charge_for_order
 
 

--- a/tickets/admin.py
+++ b/tickets/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/tickets/constants.py
+++ b/tickets/constants.py
@@ -7,14 +7,14 @@ DAYS = {
 }
 
 RATES = {
-  # These numbers are plucked out of the air
-  # If these values change, also update tickets.js
-  'individual': {
-    'ticket_price': 18,
-    'day_price': 24,
-  },
-  'corporate': {
-    'ticket_price': 36,
-    'day_price': 48,
-  },
+    # These numbers are plucked out of the air
+    # If these values change, also update tickets.js
+    'individual': {
+        'ticket_price': 18,
+        'day_price': 24,
+    },
+    'corporate': {
+        'ticket_price': 36,
+        'day_price': 48,
+    },
 }

--- a/tickets/invitation_mailer.py
+++ b/tickets/invitation_mailer.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.core.mail import send_mail
-from django.urls import reverse
+
 
 INVITATION_TEMPLATE = '''
 Hello!

--- a/tickets/tests/test_actions.py
+++ b/tickets/tests/test_actions.py
@@ -108,6 +108,7 @@ class ProcessStripeChargeTests(TestCase):
         self.assertEqual(self.order.status, 'failed')
         self.assertEqual(len(mail.outbox), 0)
 
+
 class TicketInvitationTests(TestCase):
     def test_claim_ticket_invitation(self):
         alice = User.objects.create_user(username='Alice')

--- a/tickets/tests/test_forms.py
+++ b/tickets/tests/test_forms.py
@@ -1,4 +1,3 @@
-from django.http import QueryDict
 from django.test import TestCase
 
 from .utils import build_querydict
@@ -15,7 +14,7 @@ class TicketForOthersFormSetTests(TestCase):
             'form-MAX_NUM_FORMS': '1000',
             'form-0-email_addr': 'test1@example.com',
             'form-0-days': ['thu', 'fri'],
-            'form-1-email_addr': 'test2@example.com', 
+            'form-1-email_addr': 'test2@example.com',
             'form-1-days': ['sat', 'sun', 'mon']
         })
 
@@ -30,7 +29,7 @@ class TicketForOthersFormSetTests(TestCase):
             'form-MAX_NUM_FORMS': '1000',
             'form-0-email_addr': 'test1@example.com',
             'form-0-days': ['thu', 'fri'],
-            'form-1-email_addr': '', 
+            'form-1-email_addr': '',
         })
 
         formset = forms.TicketForOthersFormSet(post_data)
@@ -44,7 +43,7 @@ class TicketForOthersFormSetTests(TestCase):
             'form-MAX_NUM_FORMS': '1000',
             'form-0-email_addr': 'test1@example.com',
             'form-0-days': ['thu', 'fri'],
-            'form-1-email_addr': '', 
+            'form-1-email_addr': '',
             'form-1-days': ['sat', 'sun', 'mon']
         })
 
@@ -62,7 +61,7 @@ class TicketForOthersFormSetTests(TestCase):
             'form-MAX_NUM_FORMS': '1000',
             'form-0-email_addr': 'test1@example.com',
             'form-0-days': ['thu', 'fri'],
-            'form-1-email_addr': 'test2@example.com', 
+            'form-1-email_addr': 'test2@example.com',
         })
 
         formset = forms.TicketForOthersFormSet(post_data)
@@ -78,7 +77,7 @@ class TicketForOthersFormSetTests(TestCase):
             'form-MIN_NUM_FORMS': '1',
             'form-MAX_NUM_FORMS': '1000',
             'form-0-email_addr': '',
-            'form-1-email_addr': '', 
+            'form-1-email_addr': '',
         })
 
         formset = forms.TicketForOthersFormSet(post_data)
@@ -95,7 +94,7 @@ class TicketForOthersFormSetTests(TestCase):
             'form-MAX_NUM_FORMS': '1000',
             'form-0-email_addr': 'test1@example.com',
             'form-0-days': ['thu', 'fri'],
-            'form-1-email_addr': 'test2@example.com', 
+            'form-1-email_addr': 'test2@example.com',
             'form-1-days': ['sat', 'sun', 'mon']
         })
 

--- a/tickets/tests/test_stripe_integration.py
+++ b/tickets/tests/test_stripe_integration.py
@@ -5,7 +5,6 @@ from django.contrib.auth.models import User
 from .utils import patched_charge_creation_failure, patched_charge_creation_success
 
 from tickets import actions
-from tickets import models
 from tickets import stripe_integration
 
 

--- a/tickets/tests/test_views.py
+++ b/tickets/tests/test_views.py
@@ -27,7 +27,7 @@ class NewOrderTests(TestCase):
             'form-MIN_NUM_FORMS': '1',
             'form-MAX_NUM_FORMS': '1000',
             'form-0-email_addr': '',
-            'form-1-email_addr': '', 
+            'form-1-email_addr': '',
         }
         rsp = self.client.post('/tickets/orders/new/', form_data, follow=True)
         self.assertContains(rsp, 'You have ordered 1 ticket(s)')
@@ -42,7 +42,7 @@ class NewOrderTests(TestCase):
             'form-MAX_NUM_FORMS': '1000',
             'form-0-email_addr': 'test1@example.com',
             'form-0-days': ['thu', 'fri'],
-            'form-1-email_addr': 'test2@example.com', 
+            'form-1-email_addr': 'test2@example.com',
             'form-1-days': ['sat', 'sun', 'mon'],
         }
         rsp = self.client.post('/tickets/orders/new/', form_data, follow=True)
@@ -59,7 +59,7 @@ class NewOrderTests(TestCase):
             'form-MAX_NUM_FORMS': '1000',
             'form-0-email_addr': 'test1@example.com',
             'form-0-days': ['thu', 'fri'],
-            'form-1-email_addr': 'test2@example.com', 
+            'form-1-email_addr': 'test2@example.com',
             'form-1-days': ['sat', 'sun', 'mon'],
         }
         rsp = self.client.post('/tickets/orders/new/', form_data, follow=True)
@@ -103,6 +103,7 @@ class OrderPaymentTests(TestCase):
             )
         self.assertContains(rsp, 'Payment for this order failed (Your card was declined.)')
         self.assertContains(rsp, '<div id="stripe-form">')
+
 
 class TicketInvitationTests(TestCase):
     @classmethod

--- a/tickets/tests/utils.py
+++ b/tickets/tests/utils.py
@@ -31,6 +31,7 @@ def patched_charge_creation_success():
         mock.return_value = charge
         yield
 
+
 @contextmanager
 def patched_charge_creation_failure():
     card_error = stripe.error.CardError('Your card was declined.', None, 'card_declined')

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -49,7 +49,7 @@ def new_order(request):
 
             else:
                 assert False
-                    
+
     else:
         form = TicketForm()
         self_form = TicketForSelfForm()


### PR DESCRIPTION
Related to #5

This will cause local tests and TravisCI to fail when code quality issues are introduced.

I've excluded long-line checks for the moment, as there are a few warnings raised about them, and they're likely to be the most contentious.

As well as adding and (mostly) fixing flake8 checks, I've also added an [EditorConfig](http://editorconfig.org/) configuration file.

For users with an editorconfig plugin, this will help to add some level of consistency (eg: tabs vs spaces) when editing files.

TODO:

- [ ] Fix the other remaining flake8 errors.