### PR TITLE
Add checks for deployment env vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,5 @@ help:
 
 
 test:
-	STRIPE_API_KEY_PUBLISHABLE=dummy \
-	STRIPE_API_KEY_SECRET=dummy \
 	coverage run manage.py test
 	coverage report

--- a/ironcage/__init__.py
+++ b/ironcage/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'ironcage.apps.IroncageConfig'

--- a/ironcage/apps.py
+++ b/ironcage/apps.py
@@ -1,0 +1,11 @@
+from django.apps import AppConfig
+from django.core.checks import register
+
+from .checks import env_vars_check
+
+
+class IroncageConfig(AppConfig):
+    name = 'ironcage'
+
+    def ready(self):
+        register(env_vars_check, deploy=True)

--- a/ironcage/checks.py
+++ b/ironcage/checks.py
@@ -1,0 +1,12 @@
+from django.conf import settings
+from django.core.checks import Error
+
+
+def env_vars_check(app_configs, **kwargs):
+    """Ensure critical env vars are set in production."""
+    errors = []
+    for watched in settings.ENVVAR_WATCHED:
+        if getattr(settings, watched) == settings.ENVVAR_SENTINAL:
+            msg = 'Env var "{}" must be set in production.'.format(watched)
+            errors.append(Error(msg))
+    return errors

--- a/ironcage/settings.py
+++ b/ironcage/settings.py
@@ -15,7 +15,14 @@ import os
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+# Used for distinguishing settings that are unset in production.
 ENVVAR_SENTINAL = 'not-for-production'
+# Settings that must be set in production.
+ENVVAR_WATCHED = [
+    'SECRET_KEY',
+    'STRIPE_API_KEY_PUBLISHABLE',
+    'STRIPE_API_KEY_SECRET',
+]
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
@@ -35,6 +42,7 @@ DOMAIN = 'http://localhost:8000'
 # Application definition
 
 INSTALLED_APPS = [
+    'ironcage',
     'tickets',
 
     'django.contrib.admin',

--- a/ironcage/settings.py
+++ b/ironcage/settings.py
@@ -15,12 +15,13 @@ import os
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+ENVVAR_SENTINAL = 'not-for-production'
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '$fv1g2*1=9ke)#ro@9di4ss-*bqs#na*zif75ba_$podh7)do-'
+SECRET_KEY = os.environ.get('SECRET_KEY', ENVVAR_SENTINAL)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -130,5 +131,5 @@ STATICFILES_DIRS = [
 
 # Stripe
 
-STRIPE_API_KEY_PUBLISHABLE = os.environ['STRIPE_API_KEY_PUBLISHABLE']
-STRIPE_API_KEY_SECRET = os.environ['STRIPE_API_KEY_SECRET']
+STRIPE_API_KEY_PUBLISHABLE = os.environ.get('STRIPE_API_KEY_PUBLISHABLE', ENVVAR_SENTINAL)
+STRIPE_API_KEY_SECRET = os.environ.get('STRIPE_API_KEY_SECRET', ENVVAR_SENTINAL)

--- a/ironcage/tests/test_apps.py
+++ b/ironcage/tests/test_apps.py
@@ -1,0 +1,22 @@
+from unittest import mock
+
+from django.apps import apps
+from django.test import TestCase
+
+from ..apps import IroncageConfig
+from ..checks import env_vars_check
+
+
+class TestIroncageConfig(TestCase):
+    def test_registered(self):
+        """IroncageConfig is used as the config for the ironcage app."""
+        self.assertIsInstance(apps.get_app_config('ironcage'), IroncageConfig)
+
+    def test_checks_registered_on_ready(self):
+        """The ready() method registers checks."""
+        app_config = apps.get_app_config('ironcage')
+        register_path = 'ironcage.apps.register'
+        with mock.patch(register_path) as register:
+            app_config.ready()
+
+        register.assert_called_once_with(env_vars_check, deploy=True)

--- a/ironcage/tests/test_checks.py
+++ b/ironcage/tests/test_checks.py
@@ -1,0 +1,27 @@
+from django.core.checks import Error
+from django.test import override_settings, TestCase
+
+from ..checks import env_vars_check
+
+
+class EnvVarsCheckTest(TestCase):
+    """Tests for env_vars_check."""
+    def test_unset_in_prod(self):
+        """When keys are unset, return an error for each."""
+        errors = env_vars_check(None)
+        expected = [
+            Error('Env var "SECRET_KEY" must be set in production.'),
+            Error('Env var "STRIPE_API_KEY_PUBLISHABLE" must be set in production.'),
+            Error('Env var "STRIPE_API_KEY_SECRET" must be set in production.'),
+        ]
+        self.assertEqual(errors, expected)
+
+    @override_settings(
+            SECRET_KEY='changed',
+            STRIPE_API_KEY_PUBLISHABLE='changed',
+            STRIPE_API_KEY_SECRET='changed',
+    )
+    def test_set_in_prod(self):
+        """If all's well in production, no need to return any errors."""
+        errors = env_vars_check(None)
+        self.assertEqual(errors, [])


### PR DESCRIPTION
This adds a check for the following env vars:

- `SECRET_KEY`
- `STRIPE_API_KEY_PUBLISHABLE`
- `STRIPE_API_KEY_SECRET`

Fixes #41 

These checks are run when `./manage.py check --deploy` is run, so we should consider running that on deployment. That's also going to be handy as part of #22.